### PR TITLE
:sparkles: Add autolink to issues and PRs in commit subject and body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### Added
 
-- :sparkles: Group commits by changelog types (#11) ([7b8b49b](https://github.com/frinyvonnick/gitmoji-changelog/commit/7b8b49b366d3d51f0cc75f4ffb67efcd633cca16))
-- :sparkles: Use handlebars templating to generate markdown (#10) ([141d160](https://github.com/frinyvonnick/gitmoji-changelog/commit/141d1601fd1fa3b278db05acbc8f47e2bb239bbf))
-- :sparkles: Generate changelog for the next release (#8) ([2d783e4](https://github.com/frinyvonnick/gitmoji-changelog/commit/2d783e44e7d4b84a993237e27b95a5d27532426b))
-- :sparkles: Implement format option (#5) ([9b7287d](https://github.com/frinyvonnick/gitmoji-changelog/commit/9b7287d167637b7a02387cea135d1d7d44a90695))
+- :sparkles: support commit url in changelog ([02c72b0](https://github.com/frinyvonnick/gitmoji-changelog/commit/02c72b0214a8b3219bc69969321de6ba0b663b26))
+- :sparkles: Group commits by changelog types ([#11](https://github.com/frinyvonnick/gitmoji-changelog/issues/11)) ([7b8b49b](https://github.com/frinyvonnick/gitmoji-changelog/commit/7b8b49b366d3d51f0cc75f4ffb67efcd633cca16))
+- :sparkles: Use handlebars templating to generate markdown ([#10](https://github.com/frinyvonnick/gitmoji-changelog/issues/10)) ([141d160](https://github.com/frinyvonnick/gitmoji-changelog/commit/141d1601fd1fa3b278db05acbc8f47e2bb239bbf))
+- :sparkles: Generate changelog for the next release ([#8](https://github.com/frinyvonnick/gitmoji-changelog/issues/8)) ([2d783e4](https://github.com/frinyvonnick/gitmoji-changelog/commit/2d783e44e7d4b84a993237e27b95a5d27532426b))
+- :sparkles: Implement format option ([#5](https://github.com/frinyvonnick/gitmoji-changelog/issues/5)) ([9b7287d](https://github.com/frinyvonnick/gitmoji-changelog/commit/9b7287d167637b7a02387cea135d1d7d44a90695))
 - :sparkles: Convert changelog to markdown ([b165f69](https://github.com/frinyvonnick/gitmoji-changelog/commit/b165f695f4c1a49ff16a5f03918545bfb36cf367))
 - :sparkles: Generate markdown first draft function ([10c6d3e](https://github.com/frinyvonnick/gitmoji-changelog/commit/10c6d3e20b82f5a0f6ce5cd372899e6519bc2412))
 - :tada: Intialize markdown project ([a4a12bb](https://github.com/frinyvonnick/gitmoji-changelog/commit/a4a12bb4f7133e7e5e40436da4c884f135abf03d))
@@ -20,7 +21,7 @@
 
 ### Changed
 
-- :recycle: remove babel to use native node 10 (#3) ([6edd0c4](https://github.com/frinyvonnick/gitmoji-changelog/commit/6edd0c48591e935f3bcd7e73d48733e623f779d9))
+- :recycle: remove babel to use native node 10 ([#3](https://github.com/frinyvonnick/gitmoji-changelog/issues/3)) ([6edd0c4](https://github.com/frinyvonnick/gitmoji-changelog/commit/6edd0c48591e935f3bcd7e73d48733e623f779d9))
 - :truck: move parse functions into parser.js ([e29f239](https://github.com/frinyvonnick/gitmoji-changelog/commit/e29f239dee8dc393caee9d320371e54a37eb90ae))
 - :wrench: Fix main script in core module ([7f091a3](https://github.com/frinyvonnick/gitmoji-changelog/commit/7f091a3900605ee9bc44e793ddbb10a7272112fa))
 - :wrench: Add build script ([efbc04d](https://github.com/frinyvonnick/gitmoji-changelog/commit/efbc04d902ac201b128a8e02692b778eff109b12))

--- a/packages/gitmoji-changelog-core/package.json
+++ b/packages/gitmoji-changelog-core/package.json
@@ -22,6 +22,7 @@
     "git-raw-commits": "^2.0.0",
     "git-remote-origin-url": "^2.0.0",
     "git-semver-tags": "^2.0.0",
+    "lodash": "^4.17.11",
     "normalize-package-data": "^2.4.0",
     "read-pkg-up": "^4.0.0",
     "split-lines": "^2.0.0",

--- a/packages/gitmoji-changelog-core/src/gitInfo.js
+++ b/packages/gitmoji-changelog-core/src/gitInfo.js
@@ -2,6 +2,7 @@ const readPkgUp = require('read-pkg-up')
 const getPkgRepo = require('get-pkg-repo')
 const gitRemoteOriginUrl = require('git-remote-origin-url')
 const normalizePackageData = require('normalize-package-data')
+const { isEmpty } = require('lodash')
 
 async function getGitInfo() {
   // get the closest package.json file
@@ -32,6 +33,27 @@ async function getGitInfo() {
   }
 }
 
+function getHashUrl(hash, gitInfo) {
+  if (!hash) return null
+
+  if (isEmpty(gitInfo)) return null
+
+  return `${gitInfo.browse()}/commit/${hash}`
+}
+
+function autolink(message, gitInfo) {
+  if (!message) return null
+
+  if (isEmpty(gitInfo)) return message
+
+  const matches = message.match(/#{1}(\d+)/gm)
+  if (!matches) return message
+
+  return message.replace(/#{1}(\d+)/gm, `[#$1](${gitInfo.bugs()}/$1)`)
+}
+
 module.exports = {
   getGitInfo,
+  getHashUrl,
+  autolink,
 }

--- a/packages/gitmoji-changelog-core/src/gitInfo.spec.js
+++ b/packages/gitmoji-changelog-core/src/gitInfo.spec.js
@@ -2,9 +2,9 @@
 const readPkgUp = require('read-pkg-up')
 const gitRemoteOriginUrl = require('git-remote-origin-url')
 
-const { getGitInfo } = require('./gitInfo')
+const { getGitInfo, autolink, getHashUrl } = require('./gitInfo')
 
-describe('gitInfo', () => {
+describe('getGitInfo', () => {
   it('should extract repo info from package.json', async () => {
     readPkgUp.mockImplementationOnce(() => Promise.resolve({
       pkg: {
@@ -50,6 +50,57 @@ describe('gitInfo', () => {
     const result = await getGitInfo()
 
     expect(result).toBeNull()
+  })
+})
+
+
+describe('getHashUrl', () => {
+  it('should return null if no hash given', async () => {
+    const result = getHashUrl()
+    expect(result).toBeNull()
+  })
+
+  it('should return null if no gitInfo given', async () => {
+    const result = getHashUrl('xxx')
+    expect(result).toBeNull()
+  })
+
+  it('should return the url of a hash', async () => {
+    const result = getHashUrl('xxx', {
+      browse: () => 'https://github.com/frinyvonnick/gitmoji-changelog',
+    })
+    expect(result).toBe('https://github.com/frinyvonnick/gitmoji-changelog/commit/xxx')
+  })
+})
+
+describe('autolink', () => {
+  it('should return null if no message given', async () => {
+    const result = autolink()
+    expect(result).toBeNull()
+  })
+
+  it('should return the message if no gitInfo given', async () => {
+    const result = autolink('message without gitinfo')
+    expect(result).toBe('message without gitinfo')
+  })
+
+  it('should return the message if nothing match', async () => {
+    const result = autolink('nothing match in this message')
+    expect(result).toBe('nothing match in this message')
+  })
+
+  it('should autolink one hashtag issue in message', async () => {
+    const result = autolink(':bug: fix issue #123', {
+      bugs: () => 'https://github.com/frinyvonnick/gitmoji-changelog/issues',
+    })
+    expect(result).toBe(':bug: fix issue [#123](https://github.com/frinyvonnick/gitmoji-changelog/issues/123)')
+  })
+
+  it('should autolink severals hashtag issues in message', async () => {
+    const result = autolink(':bug: fix issue #123 and #456', {
+      bugs: () => 'https://github.com/frinyvonnick/gitmoji-changelog/issues',
+    })
+    expect(result).toBe(':bug: fix issue [#123](https://github.com/frinyvonnick/gitmoji-changelog/issues/123) and [#456](https://github.com/frinyvonnick/gitmoji-changelog/issues/456)')
   })
 })
 

--- a/packages/gitmoji-changelog-core/src/parser.js
+++ b/packages/gitmoji-changelog-core/src/parser.js
@@ -1,5 +1,6 @@
 const splitLines = require('split-lines')
 const mapping = require('./mapping')
+const { getHashUrl, autolink } = require('./gitInfo')
 
 function parseSubject(subject) {
   if (!subject) return {}
@@ -33,13 +34,15 @@ function parseCommit(commit, gitInfo) {
   return {
     hash,
     shortHash: hash.slice(0, 7),
-    urlHash: gitInfo && `${gitInfo.browse()}/commit/${hash}`,
+    urlHash: getHashUrl(hash, gitInfo),
     date,
-    subject,
     emoji,
-    message,
     group,
-    body: body.join('\n'),
+    rawSubject: subject,
+    subject: autolink(subject, gitInfo),
+    message: autolink(message, gitInfo),
+    rawBody: body.join('\n'),
+    body: autolink(body.join('\n'), gitInfo),
   }
 }
 

--- a/packages/gitmoji-changelog-core/src/parser.spec.js
+++ b/packages/gitmoji-changelog-core/src/parser.spec.js
@@ -31,7 +31,7 @@ describe('commits parser', () => {
 
     expect(parseCommit(commit)).toEqual(expect.objectContaining({
       ...sparklesCommit,
-      body: '',
+      body: null,
     }))
   })
 
@@ -44,8 +44,8 @@ describe('commits parser', () => {
 
     expect(parseCommit(commit)).toEqual(expect.objectContaining({
       ...sparklesCommit,
-      subject: '',
-      body: '',
+      subject: null,
+      body: null,
     }))
   })
 


### PR DESCRIPTION
Based on PR #16 

Commit subject and body can now be autolinked to issues and PRs if git info are retreived.

You can see the result here:
