### PR TITLE
:sparkles: Add the author in changelog lines

### DIFF
--- a/packages/gitmoji-changelog-cli/src/index.js
+++ b/packages/gitmoji-changelog-cli/src/index.js
@@ -48,6 +48,7 @@ yargs
 
   .option('format', { default: 'markdown', desc: 'changelog format (markdown, json)' })
   .option('output', { desc: 'output changelog file' })
+  .option('author', { default: false, desc: 'add the author in changelog lines' })
 
   .help('help')
   .epilog(`For more information visit: ${homepage}`)

--- a/packages/gitmoji-changelog-core/src/index.js
+++ b/packages/gitmoji-changelog-core/src/index.js
@@ -14,7 +14,7 @@ const logger = require('./logger')
 
 const gitSemverTagsAsync = promisify(gitSemverTags)
 
-const COMMIT_FORMAT = '%n%H%n%cI%n%s%n%b'
+const COMMIT_FORMAT = '%n%H%n%an%n%cI%n%s%n%b'
 
 function getCommits(from, to) {
   return new Promise((resolve) => {

--- a/packages/gitmoji-changelog-core/src/index.spec.js
+++ b/packages/gitmoji-changelog-core/src/index.spec.js
@@ -6,6 +6,7 @@ const { generateChangelog } = require('./index')
 
 const sparklesCommit = {
   hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23a',
+  author: 'John Doe',
   date: '2018-08-28T10:06:00+02:00',
   subject: ':sparkles: Upgrade brand new feature',
   body: 'Waouh this is awesome 2',
@@ -17,6 +18,7 @@ const sparklesCommit = {
 
 const recycleCommit = {
   hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c',
+  author: 'John Doe',
   date: '2018-08-01T10:07:00+02:00',
   subject: ':recycle: Upgrade brand new feature',
   body: 'Waouh this is awesome 3',
@@ -28,6 +30,7 @@ const recycleCommit = {
 
 const secondRecycleCommit = {
   hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23d',
+  author: 'John Doe',
   date: '2018-08-30T10:07:00+02:00',
   subject: ':recycle: Upgrade another brand new feature',
   body: 'Waouh this is awesome 4',
@@ -39,6 +42,7 @@ const secondRecycleCommit = {
 
 const lipstickCommit = {
   hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23e',
+  author: 'John Doe',
   date: '2018-08-10T10:07:00+02:00',
   subject: ':lipstick: Change graphics for a feature',
   body: 'Waouh this is awesome 5',
@@ -50,6 +54,7 @@ const lipstickCommit = {
 
 const secondLipstickCommit = {
   hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23f',
+  author: 'John Doe',
   date: '2018-08-18T10:07:00+02:00',
   subject: ':lipstick: Change more graphics for a feature',
   body: 'Waouh this is awesome 6',
@@ -167,9 +172,9 @@ function mockGroup(commits) {
     const readable = new stream.Readable()
     commits.forEach(commit => {
       const {
-        hash, date, subject, body,
+        hash, author, date, subject, body,
       } = commit
-      readable.push(`\n${hash}\n${date}\n${subject}\n${body}\n`)
+      readable.push(`\n${hash}\n${author}\n${date}\n${subject}\n${body}\n`)
     })
     readable.push(null)
     readable.emit('close')

--- a/packages/gitmoji-changelog-core/src/parser.js
+++ b/packages/gitmoji-changelog-core/src/parser.js
@@ -39,12 +39,13 @@ function getCommitGroup(emojiCode) {
 
 function parseCommit(commit) {
   const lines = splitLines(commit)
-  const [hash, date, subject, ...body] = lines.splice(1, lines.length - 2)
+  const [hash, author, date, subject, ...body] = lines.splice(1, lines.length - 2)
   const { emoji, emojiCode, message } = parseSubject(subject)
   const group = getCommitGroup(emojiCode)
 
   return {
     hash,
+    author,
     date,
     subject,
     emojiCode,

--- a/packages/gitmoji-changelog-core/src/parser.spec.js
+++ b/packages/gitmoji-changelog-core/src/parser.spec.js
@@ -2,6 +2,7 @@ const { parseCommit } = require('./parser.js')
 
 const sparklesCommit = {
   hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23f',
+  author: 'John Doe',
   date: '2018-08-28T10:06:00+02:00',
   subject: ':sparkles: Upgrade brand new feature',
   body: 'Waouh this is awesome 2',
@@ -12,11 +13,12 @@ describe('commits parser', () => {
   it('should parse a single commit', () => {
     const {
       hash,
+      author,
       date,
       subject,
       body,
     } = sparklesCommit
-    const commit = `\n${hash}\n${date}\n${subject}\n${body}\n`
+    const commit = `\n${hash}\n${author}\n${date}\n${subject}\n${body}\n`
 
     expect(parseCommit(commit)).toEqual(expect.objectContaining(sparklesCommit))
   })
@@ -24,10 +26,11 @@ describe('commits parser', () => {
   it('should parse a unicode emoji', () => {
     const {
       hash,
+      author,
       date,
       body,
     } = sparklesCommit
-    const commit = `\n${hash}\n${date}\n✨ Upgrade brand new feature\n${body}\n`
+    const commit = `\n${hash}\n${author}\n${date}\n✨ Upgrade brand new feature\n${body}\n`
     const parsed = parseCommit(commit)
     expect(parsed.emoji).toEqual('✨')
     expect(parsed.emojiCode).toEqual('sparkles')
@@ -37,10 +40,11 @@ describe('commits parser', () => {
   it('should parse a single commit without a body', () => {
     const {
       hash,
+      author,
       date,
       subject,
     } = sparklesCommit
-    const commit = `\n${hash}\n${date}\n${subject}\n\n`
+    const commit = `\n${hash}\n${author}\n${date}\n${subject}\n\n`
 
     expect(parseCommit(commit)).toEqual(expect.objectContaining({
       ...sparklesCommit,
@@ -51,9 +55,10 @@ describe('commits parser', () => {
   it('should parse a single commit without a subject', () => {
     const {
       hash,
+      author,
       date,
     } = sparklesCommit
-    const commit = `\n${hash}\n${date}\n\n`
+    const commit = `\n${hash}\n${author}\n${date}\n\n`
 
     expect(parseCommit(commit)).toEqual(expect.objectContaining({
       ...sparklesCommit,
@@ -65,11 +70,12 @@ describe('commits parser', () => {
   it('should add the group to a commit', () => {
     const {
       hash,
+      author,
       date,
       subject,
       body,
     } = sparklesCommit
-    const commit = `\n${hash}\n${date}\n${subject}\n${body}\n`
+    const commit = `\n${hash}\n${author}\n${date}\n${subject}\n${body}\n`
 
     expect(parseCommit(commit)).toEqual(expect.objectContaining({ group: 'added' }))
   })

--- a/packages/gitmoji-changelog-markdown/src/index.js
+++ b/packages/gitmoji-changelog-markdown/src/index.js
@@ -14,7 +14,7 @@ function buildMarkdownFile(changelog = {}, options = {}) {
   return markdownIncremental(changelog, options)
 }
 
-function toMarkdown({ meta, changes }) {
+function toMarkdown({ meta, changes }, { author }) {
   const template = fs.readFileSync(MARKDOWN_TEMPLATE, 'utf-8')
 
   const compileTemplate = handlebars.compile(template)
@@ -25,13 +25,14 @@ function toMarkdown({ meta, changes }) {
     subject: autolink(commit.subject, meta.repository),
     message: autolink(commit.message, meta.repository),
     body: autolink(commit.body, meta.repository),
+    author: author ? commit.author : null,
   }))
 
   return compileTemplate({ changelog })
 }
 
 function markdownFromScratch({ meta, changes }, options) {
-  const output = toMarkdown({ meta, changes })
+  const output = toMarkdown({ meta, changes }, options)
   return Promise.resolve(fs.writeFileSync(options.output, output))
 }
 
@@ -47,7 +48,7 @@ function markdownIncremental({ meta, changes }, options) {
 
   // write file for next version
   const writer = fs.createWriteStream(tempFile, { encoding: 'utf-8' })
-  writer.write(toMarkdown({ meta, changes }))
+  writer.write(toMarkdown({ meta, changes }, options))
 
   // read original file until last tags and add it to the end
   let lastVersionFound = false

--- a/packages/gitmoji-changelog-markdown/src/index.spec.js
+++ b/packages/gitmoji-changelog-markdown/src/index.spec.js
@@ -28,6 +28,7 @@ describe('Markdown converter', () => {
               commits: [
                 {
                   hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c',
+                  author: 'John Doe',
                   date: '2018-08-28T10:07:00+02:00',
                   subject: ':recycle: Upgrade brand new feature',
                   emoji: '♻️',
@@ -48,6 +49,7 @@ describe('Markdown converter', () => {
               commits: [
                 {
                   hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23f',
+                  author: 'John Doe',
                   date: '2018-08-28T10:06:00+02:00',
                   subject: ':sparkles: Upgrade brand new feature',
                   emoji: '✨',
@@ -72,7 +74,7 @@ describe('Markdown converter', () => {
 
 ### Changed
 
-- ♻️ Upgrade brand new feature ([c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c))
+- ♻️ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c)] (by John Doe)
 
 
 <a name="1.0.0"></a>
@@ -80,7 +82,7 @@ describe('Markdown converter', () => {
 
 ### Added
 
-- ✨ Upgrade brand new feature ([c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23f))
+- ✨ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23f)] (by John Doe)
 
 
 `)
@@ -115,6 +117,7 @@ describe('Markdown converter', () => {
               commits: [
                 {
                   hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c',
+                  author: 'John Doe',
                   date: '2018-08-28T10:07:00+02:00',
                   subject: ':recycle: Upgrade brand new feature',
                   emoji: '♻️',
@@ -140,7 +143,7 @@ describe('Markdown converter', () => {
 
 ### Changed
 
-- ♻️ Upgrade brand new feature ([c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c))
+- ♻️ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c)] (by John Doe)
 
 
 `)

--- a/packages/gitmoji-changelog-markdown/src/index.spec.js
+++ b/packages/gitmoji-changelog-markdown/src/index.spec.js
@@ -74,7 +74,7 @@ describe('Markdown converter', () => {
 
 ### Changed
 
-- ♻️ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c)] (by John Doe)
+- ♻️ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c)]
 
 
 <a name="1.0.0"></a>
@@ -82,7 +82,62 @@ describe('Markdown converter', () => {
 
 ### Added
 
-- ✨ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23f)] (by John Doe)
+- ✨ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23f)]
+
+
+`)
+  })
+
+  it('should generate full changelog into markdown from scratch with author', async () => {
+    fs.writeFileSync = jest.fn()
+
+    const changelog = {
+      meta: {
+        repository: {
+          type: 'github',
+          domain: 'github.com',
+          user: 'frinyvonnick',
+          project: 'gitmoji-changelog',
+          url: 'https://github.com/frinyvonnick/gitmoji-changelog',
+          bugsUrl: 'https://github.com/frinyvonnick/gitmoji-changelog/issues',
+        },
+      },
+      changes: [
+        {
+          version: 'next',
+          groups: [
+            {
+              group: 'changed',
+              label: 'Changed',
+              commits: [
+                {
+                  hash: 'c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c',
+                  author: 'John Doe',
+                  date: '2018-08-28T10:07:00+02:00',
+                  subject: ':recycle: Upgrade brand new feature',
+                  emoji: '♻️',
+                  message: 'Upgrade brand new feature',
+                  body: 'Waouh this is awesome 3',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    await buildMarkdownFile(changelog, { mode: 'init', output: './CHANGELOG.md', author: true })
+
+    expect(fs.writeFileSync.mock.calls[0].length).toBe(2)
+    expect(fs.writeFileSync.mock.calls[0][0]).toBe('./CHANGELOG.md')
+    expect(fs.writeFileSync.mock.calls[0][1]).toEqual(`# Changelog
+
+<a name="next"></a>
+## next
+
+### Changed
+
+- ♻️ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c)] (by John Doe)
 
 
 `)
@@ -143,7 +198,7 @@ describe('Markdown converter', () => {
 
 ### Changed
 
-- ♻️ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c)] (by John Doe)
+- ♻️ Upgrade brand new feature [[c40ee86](https://github.com/frinyvonnick/gitmoji-changelog/commit/c40ee8669ba7ea5151adc2942fa8a7fc98d9e23c)]
 
 
 `)

--- a/packages/gitmoji-changelog-markdown/src/template.md
+++ b/packages/gitmoji-changelog-markdown/src/template.md
@@ -8,7 +8,7 @@
 ### {{label}}
 
 {{#each commits}}
-- {{emoji}} {{message}} ({{hash}})
+- {{emoji}} {{message}} [{{hash}}] (by {{author}})
 {{/each}}
 
 {{/each}}

--- a/packages/gitmoji-changelog-markdown/src/template.md
+++ b/packages/gitmoji-changelog-markdown/src/template.md
@@ -8,7 +8,7 @@
 ### {{label}}
 
 {{#each commits}}
-- {{emoji}} {{message}} [{{hash}}] (by {{author}})
+- {{emoji}} {{message}} [{{hash}}]{{#if author}} (by {{author}}){{/if}}
 {{/each}}
 
 {{/each}}


### PR DESCRIPTION
Closes #55 

>  In git commits we have the "author fullname" and "author email" but we can't have the github/gitlab... username

## Example of final result:
![image](https://user-images.githubusercontent.com/516360/47609190-5d1dea00-da3a-11e8-9054-4f9db981f7ec.png)

## Proposal
Keep it in that way but add an option to cli to add or not the author in the changelog. Because in some project when only one person work on it, he may not want to have the same author on each line (it doesnt bring value to the changelog)

So I propose to have the following option to activate it:
```bash
gitmoji-changelog --with-author
```