### PR TITLE
:whale: Init dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM  mhart/alpine-node:11.0.0
+
+# install dependencies
+RUN apk add git
+
+# build gitmoji-changelog from source
+COPY . /usr/src/gitmoji-changelog
+WORKDIR /usr/src/gitmoji-changelog
+RUN yarn
+
+# this folder is the target of the host folder that contains git repository
+WORKDIR /usr/src/app
+
+# run gitmoji-changelog on /usr/src/app
+ENTRYPOINT ["/usr/src/gitmoji-changelog/node_modules/.bin/gitmoji-changelog"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:10-alpine
 
 # install dependencies
-RUN apk add git
+RUN apk add --no-cache git
 ENV NODE_ENV=production
 
 # build gitmoji-changelog from source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
-FROM  mhart/alpine-node:11.0.0
+FROM node:10-alpine
 
 # install dependencies
 RUN apk add git
+ENV NODE_ENV=production
 
 # build gitmoji-changelog from source
 COPY . /usr/src/gitmoji-changelog
 WORKDIR /usr/src/gitmoji-changelog
 RUN yarn
-
-# this folder is the target of the host folder that contains git repository
-WORKDIR /usr/src/app
 
 # run gitmoji-changelog on /usr/src/app
 ENTRYPOINT ["/usr/src/gitmoji-changelog/node_modules/.bin/gitmoji-changelog"]


### PR DESCRIPTION
I had 2 options to write this Dockerfile:
1. Build the `gitmoji-changelog` "binary" from source
1. Install the binary from npm registry

Even if the second option offers a lighter Docker Image (102MB) compared to the first one (263MB), I chose the first one because I think we cannot build a Docker Image based on "binary" from "https://registry.npmjs.org/gitmoji-changelog" until it is available (but I maybe wrong, just tell me).

So, this Dockerfile:
- copy sources of `gitmoji-changelog`
- then build them by using `yarn`
- and define the entrypoint to `/usr/src/gitmoji-changelog/node_modules/.bin/gitmoji-changelog`

### Usage
`docker run --rm -v $(pwd):/usr/src/app gitmoji-changelog` where `$(pwd)` is the folder of the project you want to generate the CHANGELOG.md.

All Commands, Positionals and Options are available with `docker run` command.
For instance, `docker run --rm -v $(pwd):$(pwd) -w $(pwd) gitmoji-changelog:1.0.0 --help` outputs:
```
Usage: gitmoji-changelog <command> [options]

Commands:
  gitmoji-changelog [release]         Generate changelog               [default]
  gitmoji-changelog init              Initialize changelog from tags
  gitmoji-changelog update [release]  Update changelog with a new version

Positionals:
  release  Next version (from-package, next)           [default: "from-package"]

Options:
  --version  Show version number                                       [boolean]
  --format   changelog format (markdown, json)             [default: "markdown"]
  --output   output changelog file
  --help     Show help                                                 [boolean]

For more information visit:
https://github.com/frinyvonnick/gitmoji-changelog#readme
```

Closes #29 