### PR TITLE
:sparkles: Add a breaking changes section

### DIFF
--- a/packages/gitmoji-changelog-core/src/groupMapping.js
+++ b/packages/gitmoji-changelog-core/src/groupMapping.js
@@ -29,7 +29,6 @@ module.exports = [
       'rewind',
       'alien',
       'truck',
-      'boom',
       'bento',
       'wheelchair',
       'speech_balloon',
@@ -37,6 +36,13 @@ module.exports = [
       'children_crossing',
       'building_construction',
       'iphone',
+    ],
+  },
+  {
+    group: 'breaking_changes',
+    label: 'Breaking changes',
+    emojis: [
+      'boom',
     ],
   },
   {


### PR DESCRIPTION
Just change the group of the `:boom:` gitmoji from `changed` to `breaking_changes`.

Closes #57 