### PR TITLE
:whale: small Dockerfile improvment and updated docker image usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:10.16.0-alpine
+ENV NODE_ENV=production
 
 # install dependencies
 RUN apk add --no-cache git=2.20.1-r0
-ENV NODE_ENV=production
 
 # build gitmoji-changelog from source
 WORKDIR /usr/src/gitmoji-changelog
@@ -11,4 +11,5 @@ RUN yarn --frozen-lockfile && yarn cache clean
 
 # run gitmoji-changelog on container startup
 RUN ln -s /usr/src/gitmoji-changelog/node_modules/.bin/gitmoji-changelog /usr/bin
+WORKDIR /app
 ENTRYPOINT ["gitmoji-changelog"]

--- a/README.md
+++ b/README.md
@@ -124,15 +124,17 @@ yarn lint
 
 Launch `gitmoji-changelog` using the [official Docker image](https://hub.docker.com/r/yvonnick/gitmoji-changelog):
 ```sh
-docker container run -it -v $(pwd):/app -w /app --rm yvonnick/gitmoji-changelog:latest
+docker container run -it -v $(pwd):/app --rm yvonnick/gitmoji-changelog:latest
 ```
+
+> `/app` is the directory where gitmoji-changelog expect your project in the container.
 
 You can also build the image locally and use it directly:
 ```sh
 # build the image:
 docker image build -t yvonnick/gitmoji-changelog:dev .
 # use it:
-docker container run -it -v $(pwd):/app -w /app --rm yvonnick/gitmoji-changelog:dev
+docker container run -it -v $(pwd):/app --rm yvonnick/gitmoji-changelog:dev
 ```
 
 ## Author


### PR DESCRIPTION
Fix #106 

* after some experimentation, mutli-stage build is definitely not an option with Node.js
* fixed the workdir (`/app`) where gitmoji-changelog expect the code to be inside the container
* updated docker image usage according to the modifications

