### PR TITLE
:bug: Handle pre-release as latest version in markdown

### DIFF
--- a/packages/gitmoji-changelog-cli/src/cli.e2e.js
+++ b/packages/gitmoji-changelog-cli/src/cli.e2e.js
@@ -146,6 +146,23 @@ describe('generate changelog', () => {
       expect(getChangelog()).includes(['1.0.0', '2.0.0'])
     })
 
+    it('should get two versions 1.0.0-alpha.1 and 1.0.0-alpha.2 while updating changelog after tagging a version 1.0.0-alpha.2', async () => {
+      await makeChanges('file1')
+      await commit(':sparkles: Add some file')
+      await bumpVersion('1.0.0-alpha.1')
+      gitmojiChangelog()
+      await commit(':bookmark: Version 1.0.0-alpha.1')
+      await tag('1.0.0-alpha.1')
+
+      await makeChanges('file2')
+      await commit(':sparkles: Add another file')
+      await bumpVersion('1.0.0-alpha.2')
+      await tag('1.0.0-alpha.2')
+      gitmojiChangelog()
+
+      expect(getChangelog()).includes(['1.0.0-alpha.1', '1.0.0-alpha.2'])
+    })
+
     it("should get two versions 1.0.0 and 2.0.0 while updating changelog by calling cli with 2.0.0 and having package.json's version set to 1.0.0", async () => {
       await makeChanges('file1')
       await commit(':sparkles: Add some file')

--- a/packages/gitmoji-changelog-markdown/src/index.js
+++ b/packages/gitmoji-changelog-markdown/src/index.js
@@ -116,18 +116,18 @@ async function getLatestVersion(markdownFile) {
     return null
   }
 
-  const versions = markdownContent.match(/<a name="([\w.]+?)"><\/a>/g)
+  const versions = markdownContent.match(/<a name="([\w.-]+?)"><\/a>/g)
 
   if (!versions) return null
 
   const [lastVersion, previousVersion] = versions
 
   const tags = await gitSemverTagsAsync()
-  const result = lastVersion.match(/<a name="([\w.]+?)"><\/a>/)
+  const result = lastVersion.match(/<a name="([\w.-]+?)"><\/a>/)
   const isNext = result[1] === 'next' || !tags.some(tag => semver.eq(tag, result[1]))
   if (!isNext) return result[1]
 
-  const previousResult = previousVersion.match(/<a name="([\w.]+?)"><\/a>/)
+  const previousResult = previousVersion.match(/<a name="([\w.-]+?)"><\/a>/)
   return previousResult[1]
 }
 


### PR DESCRIPTION
I had an issue where pre-release tag were detected as latest version.