### PR TITLE
:recycle: Change core function parameters from "mode" to "from" and "to"

### DIFF
--- a/packages/gitmoji-changelog-cli/src/cli.e2e.js
+++ b/packages/gitmoji-changelog-cli/src/cli.e2e.js
@@ -375,4 +375,9 @@ describe('generate changelog', () => {
     const updatedContent = content.replace(version, to)
     fs.writeFileSync(pkg, updatedContent)
   }
+
+  // eslint-disable-next-line no-unused-vars
+  function logOutput(changelog) {
+    console.log(changelog.toString('utf8'))
+  }
 })

--- a/packages/gitmoji-changelog-cli/src/cli.e2e.js
+++ b/packages/gitmoji-changelog-cli/src/cli.e2e.js
@@ -376,8 +376,11 @@ describe('generate changelog', () => {
     fs.writeFileSync(pkg, updatedContent)
   }
 
+  /*
+   * This function is useful to print cli ouput when debugging tests
+   */
   // eslint-disable-next-line no-unused-vars
-  function logOutput(changelog) {
-    console.log(changelog.toString('utf8'))
+  function logOutput(ouput) {
+    console.log(ouput.toString('utf8'))
   }
 })

--- a/packages/gitmoji-changelog-cli/src/cli.js
+++ b/packages/gitmoji-changelog-cli/src/cli.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const { get } = require('lodash')
 const { set } = require('immutadot')
 const libnpm = require('libnpm')
 const semver = require('semver')
@@ -84,7 +85,16 @@ async function getChangelog(options) {
     release,
   }
 
-  let changelog = await generateChangelog(enhancedOptions)
+  // let changelog = await generateChangelog(enhancedOptions)
+  let changelog
+  if (options.mode === 'init') {
+    changelog = await generateChangelog('', release, enhancedOptions)
+  } else {
+    const { meta } = options
+    const lastVersion = get(meta, 'lastVersion')
+
+    changelog = await generateChangelog(lastVersion, release, enhancedOptions)
+  }
 
   if (options.interactive) {
     changelog = await executeInteractiveMode(changelog)

--- a/packages/gitmoji-changelog-cli/src/cli.spec.js
+++ b/packages/gitmoji-changelog-cli/src/cli.spec.js
@@ -4,6 +4,7 @@ const { main } = require('./cli')
 
 describe('cli', () => {
   const realExitFunction = process.exit
+  const options = { preset: 'node' }
   beforeEach(() => {
     process.exit = jest.fn(() => {})
     jest.clearAllMocks()
@@ -15,13 +16,13 @@ describe('cli', () => {
   it('should throw an error if changelog generation fails', async () => {
     generateChangelog.mockRejectedValue(new Error())
 
-    await main()
+    await main(options)
 
     expect(logger.error).toHaveBeenCalled()
   })
 
   it('should call process.exit explicitly so promises are not waited for', async () => {
-    await main()
+    await main(options)
 
     expect(process.exit).toHaveBeenCalledTimes(1)
   })
@@ -31,7 +32,7 @@ describe('cli', () => {
 
     it('should print a warning about a new version', async () => {
       manifest.mockReturnValueOnce(Promise.resolve({ version: '2.0.0' }))
-      await main()
+      await main(options)
 
       expect(findOutdatedMessage()).toBeTruthy()
     })
@@ -39,11 +40,11 @@ describe('cli', () => {
     it('should NOT print a warning about a new version', async () => {
       // older version in npm registry
       manifest.mockReturnValueOnce(Promise.resolve({ version: '0.5.0' }))
-      await main()
+      await main(options)
 
       // same version in npm registry
       manifest.mockReturnValueOnce(Promise.resolve({ version: '1.0.0' }))
-      await main()
+      await main(options)
 
       expect(manifest).toHaveBeenCalledTimes(2)
       expect(findOutdatedMessage()).toBeFalsy()
@@ -51,14 +52,14 @@ describe('cli', () => {
 
     it('should NOT print a warning about a new version when request took to much time', async () => {
       manifest.mockImplementationOnce(() => new Promise((resolve) => { setTimeout(resolve, 1000, { version: '2.0.0' }) }))
-      await main()
+      await main(options)
 
       expect(findOutdatedMessage()).toBeFalsy()
     })
 
     it('should NOT print a warning about a new version when request is on error', async () => {
       manifest.mockReturnValueOnce(Promise.reject(new Error('faked error (manifest)')))
-      await main()
+      await main(options)
 
       expect(findOutdatedMessage()).toBeFalsy()
     })

--- a/packages/gitmoji-changelog-cli/src/metaInfo.spec.js
+++ b/packages/gitmoji-changelog-cli/src/metaInfo.spec.js
@@ -1,34 +1,7 @@
 /* eslint-disable global-require */
-const readPkgUp = require('read-pkg-up')
 const gitRemoteOriginUrl = require('git-remote-origin-url')
 
-const { getPackageInfo, getRepoInfo } = require('./metaInfo')
-
-describe('getPackageInfo', () => {
-  it('should extract github repo info from package.json', async () => {
-    readPkgUp.mockImplementationOnce(() => Promise.resolve({
-      pkg: {
-        name: 'gitmoji-changelog',
-        version: '0.0.1',
-        repository: {
-          type: 'git',
-          url: 'git+https://github.com/frinyvonnick/gitmoji-changelog.git',
-        },
-      },
-    }))
-
-    const result = await getPackageInfo()
-
-    expect(result).toEqual({
-      name: 'gitmoji-changelog',
-      version: '0.0.1',
-      repository: {
-        type: 'git',
-        url: 'git+https://github.com/frinyvonnick/gitmoji-changelog.git',
-      },
-    })
-  })
-})
+const { getRepoInfo } = require('./metaInfo')
 
 describe('getRepoInfo', () => {
   it('should extract github repo info from package.json', async () => {

--- a/packages/gitmoji-changelog-cli/src/metaInfo.spec.js
+++ b/packages/gitmoji-changelog-cli/src/metaInfo.spec.js
@@ -1,7 +1,34 @@
 /* eslint-disable global-require */
+const readPkgUp = require('read-pkg-up')
 const gitRemoteOriginUrl = require('git-remote-origin-url')
 
-const { getRepoInfo } = require('./metaInfo')
+const { getPackageInfo, getRepoInfo } = require('./metaInfo')
+
+describe('getPackageInfo', () => {
+  it('should extract github repo info from package.json', async () => {
+    readPkgUp.mockImplementationOnce(() => Promise.resolve({
+      pkg: {
+        name: 'gitmoji-changelog',
+        version: '0.0.1',
+        repository: {
+          type: 'git',
+          url: 'git+https://github.com/frinyvonnick/gitmoji-changelog.git',
+        },
+      },
+    }))
+
+    const result = await getPackageInfo()
+
+    expect(result).toEqual({
+      name: 'gitmoji-changelog',
+      version: '0.0.1',
+      repository: {
+        type: 'git',
+        url: 'git+https://github.com/frinyvonnick/gitmoji-changelog.git',
+      },
+    })
+  })
+})
 
 describe('getRepoInfo', () => {
   it('should extract github repo info from package.json', async () => {

--- a/packages/gitmoji-changelog-core/src/index.spec.js
+++ b/packages/gitmoji-changelog-core/src/index.spec.js
@@ -107,7 +107,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, []))
 
-    const { changes } = await generateChangelog('', 'next')
+    const { changes } = await generateChangelog('v1.0.0', 'next')
 
     expect(changes).toEqual([
       {

--- a/packages/gitmoji-changelog-core/src/index.spec.js
+++ b/packages/gitmoji-changelog-core/src/index.spec.js
@@ -86,7 +86,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, []))
 
-    const { changes } = await generateChangelog({ mode: 'init', release: 'next' })
+    const { changes } = await generateChangelog('', 'next')
 
     expect(changes).toEqual([
       {
@@ -107,7 +107,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, []))
 
-    const { changes } = await generateChangelog({ mode: 'update', release: 'next' })
+    const { changes } = await generateChangelog('', 'next')
 
     expect(changes).toEqual([
       {
@@ -129,7 +129,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.0']))
 
-    const { changes } = await generateChangelog({ mode: 'init' })
+    const { changes } = await generateChangelog('', '')
 
     expect(changes).toEqual([
       {
@@ -168,7 +168,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.0']))
 
-    const { changes } = await generateChangelog({ mode: 'update', meta: { lastVersion: 'v1.0.0' } })
+    const { changes } = await generateChangelog('v1.0.0', 'next')
 
     expect(changes).toEqual([
       {
@@ -195,7 +195,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.0']))
 
-    const { changes } = await generateChangelog({ mode: 'init', groupSimilarCommits: true })
+    const { changes } = await generateChangelog('', '', { groupSimilarCommits: true })
 
     expect(changes[0].groups[0].commits).toEqual([
       secondRecycleCommit,
@@ -213,7 +213,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, []))
 
-    const { changes } = await generateChangelog({ mode: 'init' })
+    const { changes } = await generateChangelog('', '')
 
     expect(changes).toEqual([
       expect.objectContaining({
@@ -233,7 +233,7 @@ describe('changelog', () => {
 
     let message = false
     try {
-      await generateChangelog({ mode: 'update', release: 'next' })
+      await generateChangelog('v1.0.0', 'next')
     } catch (e) {
       message = e.message
     }
@@ -247,7 +247,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.1', 'v1.0.0']))
 
-    await generateChangelog({ mode: 'init' })
+    await generateChangelog('', '')
 
     expect(gitRawCommits).toHaveBeenCalledWith(expect.objectContaining({ from: 'v1.0.1', to: '' }))
     expect(gitRawCommits).toHaveBeenCalledWith(
@@ -264,7 +264,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.0', '1.0.0', 'v1.1.1']))
 
-    const { changes } = await generateChangelog({ mode: 'init' })
+    const { changes } = await generateChangelog('', '')
 
     // inputs has 4 group (4 versions)
     // but output should only has 3, since the 3rd is empty
@@ -286,7 +286,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, []))
 
-    const { changes } = await generateChangelog({ mode: 'init' })
+    const { changes } = await generateChangelog('', '')
 
     expect(changes[0].groups[0].commits.map(({ date, body }) => ({ date, body })))
       .toEqual([

--- a/packages/gitmoji-changelog-core/src/index.spec.js
+++ b/packages/gitmoji-changelog-core/src/index.spec.js
@@ -4,6 +4,9 @@ const gitSemverTags = require('git-semver-tags')
 
 const { generateChangelog } = require('./index')
 
+const TAIL = ''
+const HEAD = ''
+
 const uselessCommit = {
   hash: '460b79497ae7e791bc8ba8475bda8f0b93630dd3',
   date: '2018-09-14T21:00:18+02:00',
@@ -86,7 +89,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, []))
 
-    const { changes } = await generateChangelog('', 'next')
+    const { changes } = await generateChangelog(TAIL, 'next')
 
     expect(changes).toEqual([
       {
@@ -129,7 +132,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.0']))
 
-    const { changes } = await generateChangelog('', '')
+    const { changes } = await generateChangelog(TAIL, HEAD)
 
     expect(changes).toEqual([
       {
@@ -195,7 +198,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.0']))
 
-    const { changes } = await generateChangelog('', '', { groupSimilarCommits: true })
+    const { changes } = await generateChangelog(TAIL, HEAD, { groupSimilarCommits: true })
 
     expect(changes[0].groups[0].commits).toEqual([
       secondRecycleCommit,
@@ -213,7 +216,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, []))
 
-    const { changes } = await generateChangelog('', '')
+    const { changes } = await generateChangelog(TAIL, HEAD)
 
     expect(changes).toEqual([
       expect.objectContaining({
@@ -247,7 +250,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.1', 'v1.0.0']))
 
-    await generateChangelog('', '')
+    await generateChangelog(TAIL, HEAD)
 
     expect(gitRawCommits).toHaveBeenCalledWith(expect.objectContaining({ from: 'v1.0.1', to: '' }))
     expect(gitRawCommits).toHaveBeenCalledWith(
@@ -264,7 +267,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.0', '1.0.0', 'v1.1.1']))
 
-    const { changes } = await generateChangelog('', '')
+    const { changes } = await generateChangelog(TAIL, HEAD)
 
     // inputs has 4 group (4 versions)
     // but output should only has 3, since the 3rd is empty
@@ -286,7 +289,7 @@ describe('changelog', () => {
 
     gitSemverTags.mockImplementation(cb => cb(null, []))
 
-    const { changes } = await generateChangelog('', '')
+    const { changes } = await generateChangelog(TAIL, HEAD)
 
     expect(changes[0].groups[0].commits.map(({ date, body }) => ({ date, body })))
       .toEqual([


### PR DESCRIPTION
I made a first separation using a prefixed function with `_` so we can discuss about it. @bpetetot I think the logic that remains in `generateChangelog` function should be moved to `cli` package. What 
do you think of it?

The diff also let me think we could get rid of `meta` from `core` package.