### PR TITLE
:sparkles: Add a generic preset that uses a configuration file

### DIFF
--- a/packages/gitmoji-changelog-cli/src/presets/generic.js
+++ b/packages/gitmoji-changelog-cli/src/presets/generic.js
@@ -1,0 +1,12 @@
+const rc = require('rc')
+
+module.exports = () => {
+  try {
+    const customConfiguration = rc('gitmoji-changelog')
+    if (!customConfiguration.configs) throw Error('Configuration not found')
+
+    return customConfiguration.project
+  } catch (e) {
+    return null
+  }
+}

--- a/packages/gitmoji-changelog-cli/src/presets/generic.spec.js
+++ b/packages/gitmoji-changelog-cli/src/presets/generic.spec.js
@@ -1,0 +1,26 @@
+const rc = require('rc')
+
+const loadProjectInfo = require('./generic.js')
+
+describe('getPackageInfo', () => {
+  it('should extract github repo info from configuration file', async () => {
+    rc.mockImplementationOnce(() => ({
+      project: {
+        name: 'gitmoji-changelog',
+        version: '0.0.1',
+        description: 'Gitmoji Changelog CLI',
+      },
+      configs: [],
+    }))
+
+    const result = await loadProjectInfo()
+
+    expect(result).toEqual({
+      name: 'gitmoji-changelog',
+      version: '0.0.1',
+      description: 'Gitmoji Changelog CLI',
+    })
+  })
+})
+
+jest.mock('rc')


### PR DESCRIPTION
Fix #157 

It uses a configuration file at project root called `.gitmoji-changelogrc` containing the following mandatory properties.

```json
{
  "project": {
    "name": "yvonnickfrin.dev",
    "description": "My blog",
    "version": "1.1.0"
  }
}
```

## Questionning

Should it be the default preset @bpetetot?