### PR TITLE
:recycle: Improve error messages from preset system

### DIFF
--- a/packages/gitmoji-changelog-cli/src/cli.e2e.js
+++ b/packages/gitmoji-changelog-cli/src/cli.e2e.js
@@ -53,6 +53,26 @@ describe('generate changelog', () => {
 
       expect(output.toString('utf8')).includes(["The preset unknown doesn't exist"])
     })
+
+    it('should throw an Error if the preset could not find configuration', () => {
+      fs.unlinkSync(path.join(testDir, 'package.json'))
+
+      const output = gitmojiChangelog()
+
+      expect(output.toString('utf8')).includes(['Cannot retrieve configuration'])
+    })
+
+    it('should throw an Error if the preset did not return a version', () => {
+      const pkg = path.join(testDir, 'package.json')
+      // eslint-disable-next-line global-require
+      const content = JSON.parse(fs.readFileSync(pkg).toString('utf8'))
+      delete content.version
+      fs.writeFileSync(pkg, JSON.stringify(content))
+
+      const output = gitmojiChangelog()
+
+      expect(output.toString('utf8')).includes(['Cannot retrieve the version from your configuration'])
+    })
   })
 
   describe('init', () => {

--- a/packages/gitmoji-changelog-cli/src/cli.js
+++ b/packages/gitmoji-changelog-cli/src/cli.js
@@ -44,6 +44,14 @@ async function main(options = {}) {
     // eslint-disable-next-line global-require
     const loadProjectInfo = require(`./presets/${options.preset}.js`)
     projectInfo = await loadProjectInfo()
+
+    if (!projectInfo) {
+      throw Error(`Cannot retrieve configuration for preset ${options.preset}.`)
+    }
+
+    if (!projectInfo.version) {
+      throw Error('Cannot retrieve the version from your configuration. Check it or you can do "gitmoji-changelog <wanted version>".')
+    }
   } catch (e) {
     logger.error(e)
     // Force quit if the requested preset doesn't exist


### PR DESCRIPTION
Fix #159 

If the preset could not find configuration it displays:

```
Cannot retrieve configuration for preset [preset name].
```

If the preset did not return the version it displays:

```
Cannot retrieve the version from your configuration. Check it or you can do "gitmoji-changelog <wanted version>".
```