### PR TITLE
🐳 Install git 2.20.2 instead of 2.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:10.16.0-alpine
 ENV NODE_ENV=production
 
 # install dependencies
-RUN apk add --no-cache git=2.20.1-r0
+RUN apk add --no-cache git=2.20.2-r0
 
 # build gitmoji-changelog from source
 WORKDIR /usr/src/gitmoji-changelog


### PR DESCRIPTION
It looks like alpine dropped package 2.20.1

fix #162 