### PR TITLE
:recycle: make core independent from the git client.

### DIFF
--- a/packages/gitmoji-changelog-core/src/fromGitFile.js
+++ b/packages/gitmoji-changelog-core/src/fromGitFile.js
@@ -1,6 +1,5 @@
-
 const gitRawCommits = require('git-raw-commits')
-
+const splitLines = require('split-lines')
 const { promisify } = require('util')
 const gitSemverTags = require('git-semver-tags')
 const through = require('through2')
@@ -8,19 +7,34 @@ const concat = require('concat-stream')
 
 const COMMIT_FORMAT = '%n%H%n%an%n%cI%n%s%n%b'
 
-const { parseCommit } = require('./parser')
+function parseCommit(commit) {
+  const lines = splitLines(commit)
+  const [hash, author, date, subject, ...body] = lines.splice(
+    1,
+    lines.length - 2
+  )
+  return {
+    hash, author, date, subject, body,
+  }
+}
 
 function getCommits(from, to) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     gitRawCommits({
       format: COMMIT_FORMAT,
       from,
       to,
-    }).pipe(through.obj((data, enc, next) => {
-      next(null, parseCommit(data.toString()))
-    })).pipe(concat(data => {
-      resolve(data)
-    }))
+    })
+      .pipe(
+        through.obj((data, enc, next) => {
+          next(null, parseCommit(data.toString()))
+        })
+      )
+      .pipe(
+        concat(data => {
+          resolve(data)
+        })
+      )
   })
 }
 

--- a/packages/gitmoji-changelog-core/src/fromGitFile.js
+++ b/packages/gitmoji-changelog-core/src/fromGitFile.js
@@ -1,0 +1,32 @@
+
+const gitRawCommits = require('git-raw-commits')
+
+const { promisify } = require('util')
+const gitSemverTags = require('git-semver-tags')
+const through = require('through2')
+const concat = require('concat-stream')
+
+const COMMIT_FORMAT = '%n%H%n%an%n%cI%n%s%n%b'
+
+const { parseCommit } = require('./parser')
+
+function getCommits(from, to) {
+  return new Promise((resolve) => {
+    gitRawCommits({
+      format: COMMIT_FORMAT,
+      from,
+      to,
+    }).pipe(through.obj((data, enc, next) => {
+      next(null, parseCommit(data.toString()))
+    })).pipe(concat(data => {
+      resolve(data)
+    }))
+  })
+}
+
+const getTags = promisify(gitSemverTags)
+
+module.exports = {
+  getTags,
+  getCommits,
+}

--- a/packages/gitmoji-changelog-core/src/index.js
+++ b/packages/gitmoji-changelog-core/src/index.js
@@ -1,35 +1,15 @@
 const semver = require('semver')
-const gitRawCommits = require('git-raw-commits')
-const gitSemverTags = require('git-semver-tags')
 const semverCompare = require('semver-compare')
-const through = require('through2')
-const concat = require('concat-stream')
-const { isEmpty } = require('lodash')
-const { promisify } = require('util')
 
-const { parseCommit, getMergedGroupMapping } = require('./parser')
+const { isEmpty } = require('lodash')
+
+const { getMergedGroupMapping } = require('./parser')
 const logger = require('./logger')
 const { groupSentencesByDistance } = require('./utils')
+const fromGitFileClient = require('./fromGitFile')
 
-const gitSemverTagsAsync = promisify(gitSemverTags)
-
-const COMMIT_FORMAT = '%n%H%n%an%n%cI%n%s%n%b'
 const HEAD = ''
 const TAIL = ''
-
-function getCommits(from, to) {
-  return new Promise((resolve) => {
-    gitRawCommits({
-      format: COMMIT_FORMAT,
-      from,
-      to,
-    }).pipe(through.obj((data, enc, next) => {
-      next(null, parseCommit(data.toString()))
-    })).pipe(concat(data => {
-      resolve(data)
-    }))
-  })
-}
 
 function makeGroups(commits) {
   if (isEmpty(commits)) return []
@@ -68,8 +48,10 @@ async function generateVersion(options) {
     to,
     version,
     groupSimilarCommits,
+    client,
   } = options
-  let commits = filterCommits(await getCommits(from, to))
+
+  let commits = filterCommits(await client.getCommits(from, to))
 
   if (groupSimilarCommits) {
     commits = groupSentencesByDistance(commits.map(commit => commit.message))
@@ -108,6 +90,7 @@ async function generateVersions({
   hasNext,
   release,
   groupSimilarCommits,
+  client,
 }) {
   let nextTag = HEAD
   const targetVersion = hasNext ? 'next' : sanitizeVersion(release)
@@ -117,7 +100,7 @@ async function generateVersions({
     const to = nextTag
     nextTag = tag
     return generateVersion({
-      from, to, version, groupSimilarCommits,
+      from, to, version, groupSimilarCommits, client,
     })
   }))
     .then(versions => versions.sort(sortVersions))
@@ -125,8 +108,8 @@ async function generateVersions({
   return changes
 }
 
-async function generateChangelog(from, to, { groupSimilarCommits } = {}) {
-  const gitTags = await gitSemverTagsAsync()
+async function generateChangelog(from, to, { groupSimilarCommits, client = fromGitFileClient } = {}) {
+  const gitTags = await client.getTags()
   let tagsToProcess = [...gitTags]
   const hasNext = hasNextVersion(gitTags, to)
 
@@ -146,6 +129,7 @@ async function generateChangelog(from, to, { groupSimilarCommits } = {}) {
     hasNext,
     release: to,
     groupSimilarCommits,
+    client,
   })
 
   if (from !== TAIL && changes.length === 1 && isEmpty(changes[0].groups)) {

--- a/packages/gitmoji-changelog-core/src/parser.js
+++ b/packages/gitmoji-changelog-core/src/parser.js
@@ -1,4 +1,3 @@
-const splitLines = require('split-lines')
 const nodeEmoji = require('node-emoji')
 const groupMapping = require('./groupMapping')
 const rc = require('rc')
@@ -57,9 +56,9 @@ function getCommitGroup(emojiCode) {
   return group.group
 }
 
-function parseCommit(commit) {
-  const lines = splitLines(commit)
-  const [hash, author, date, subject, ...body] = lines.splice(1, lines.length - 2)
+function parseCommit({
+  hash, author, date, subject = '', body = '',
+}) {
   const { emoji, emojiCode, message } = parseSubject(subject)
   const group = getCommitGroup(emojiCode)
 
@@ -73,7 +72,7 @@ function parseCommit(commit) {
     message,
     group,
     siblings: [],
-    body: body.join('\n'),
+    body: Array.isArray(body) ? body.join('\n') : body,
   }
 }
 

--- a/packages/gitmoji-changelog-core/src/parser.spec.js
+++ b/packages/gitmoji-changelog-core/src/parser.spec.js
@@ -22,42 +22,26 @@ describe('group mapping', () => {
 
 describe('commits parser', () => {
   it('should parse a single commit', () => {
-    const {
-      hash,
-      author,
-      date,
-      subject,
-      body,
-    } = sparklesCommit
-    const commit = `\n${hash}\n${author}\n${date}\n${subject}\n${body}\n`
-
-    expect(parseCommit(commit)).toEqual(expect.objectContaining(sparklesCommit))
+    expect(parseCommit(sparklesCommit)).toEqual(expect.objectContaining(sparklesCommit))
   })
 
   it('should parse a unicode emoji', () => {
-    const {
-      hash,
-      author,
-      date,
-      body,
-    } = sparklesCommit
-    const commit = `\n${hash}\n${author}\n${date}\n✨ Upgrade brand new feature\n${body}\n`
-    const parsed = parseCommit(commit)
+    const parsed = parseCommit({
+      ...sparklesCommit,
+      subject: '✨ Upgrade brand new feature',
+    })
     expect(parsed.emoji).toEqual('✨')
     expect(parsed.emojiCode).toEqual('sparkles')
     expect(parsed.message).toEqual('Upgrade brand new feature')
   })
 
   it('should parse a single commit without a body', () => {
-    const {
-      hash,
-      author,
-      date,
-      subject,
-    } = sparklesCommit
-    const commit = `\n${hash}\n${author}\n${date}\n${subject}\n\n`
+    const parsed = parseCommit({
+      ...sparklesCommit,
+      body: '',
+    })
 
-    expect(parseCommit(commit)).toEqual(expect.objectContaining({
+    expect(parseCommit(parsed)).toEqual(expect.objectContaining({
       ...sparklesCommit,
       body: '',
     }))
@@ -69,9 +53,11 @@ describe('commits parser', () => {
       author,
       date,
     } = sparklesCommit
-    const commit = `\n${hash}\n${author}\n${date}\n\n`
-
-    expect(parseCommit(commit)).toEqual(expect.objectContaining({
+    expect(parseCommit({
+      hash,
+      author,
+      date,
+    })).toEqual(expect.objectContaining({
       ...sparklesCommit,
       subject: '',
       body: '',
@@ -79,16 +65,7 @@ describe('commits parser', () => {
   })
 
   it('should add the group to a commit', () => {
-    const {
-      hash,
-      author,
-      date,
-      subject,
-      body,
-    } = sparklesCommit
-    const commit = `\n${hash}\n${author}\n${date}\n${subject}\n${body}\n`
-
-    expect(parseCommit(commit)).toEqual(expect.objectContaining({ group: 'added' }))
+    expect(parseCommit(sparklesCommit)).toEqual(expect.objectContaining({ group: 'added' }))
   })
 
   it('should handle custom commit mapping', () => {
@@ -99,16 +76,8 @@ describe('commits parser', () => {
       ],
     }
     rc.mockImplementation(() => customConfiguration)
-    const {
-      hash,
-      author,
-      date,
-      subject,
-      body,
-    } = sparklesCommit
-    const commit = `\n${hash}\n${author}\n${date}\n${subject}\n${body}\n`
 
-    expect(parseCommit(commit)).toEqual(expect.objectContaining({ group: 'custom' }))
+    expect(parseCommit(sparklesCommit)).toEqual(expect.objectContaining({ group: 'custom' }))
   })
 })
 


### PR DESCRIPTION
In order to use gitmoji-changlelog with other git clients (like a http client or other), we need to extract the dependency with the current git client (reading .git on the filesystem).

Here is a naive refactoring extracting all calls done by the current git client.

First step for #168

You can now call the core with:
```
generateChangelog(from, to, { client: myGitClient }) 
```

The client `myGitClient` must have 2 functions:
```
getTags() : Promise([string])
getCommits(fromTag: string, toTag: string) : Promise([{ hash, author, date, subject, body }])
```