### PR TITLE
🐛 Fix init command fails to get release

### DIFF
--- a/packages/gitmoji-changelog-cli/src/cli.js
+++ b/packages/gitmoji-changelog-cli/src/cli.js
@@ -132,7 +132,7 @@ async function main(options = {}) {
 async function getChangelog(options, projectInfo) {
   const repository = await getRepositoryInfo()
 
-  const release = options.release === 'from-package' ? projectInfo.version : options.release
+  const release = options.release === 'from-package' || !options.release ? projectInfo.version : options.release
 
   if (!semver.valid(release)) {
     throw new Error(`${release} is not a valid semver version.`)


### PR DESCRIPTION
The `getChangelog` function used to compare `options.release` with `from-package`, but, on the `init` command, that option is undefined.

This changes the behaviour so that, if there's no `options.release`, the package version is used instead.