### PR TITLE
:bug:(preset-node) read-pkg-up rename key

### DIFF
--- a/packages/gitmoji-changelog-cli/src/presets/node.js
+++ b/packages/gitmoji-changelog-cli/src/presets/node.js
@@ -4,7 +4,7 @@ module.exports = async () => {
   try {
     const packageInfo = await readPkgUp()
 
-    const data = packageInfo.pkg || packageInfo['package'] || packageInfo.packageJson;
+    const data = packageInfo.pkg || packageInfo.package || packageInfo.packageJson
     if (!data) throw Error('Empty package.json')
 
     return {

--- a/packages/gitmoji-changelog-cli/src/presets/node.js
+++ b/packages/gitmoji-changelog-cli/src/presets/node.js
@@ -4,12 +4,13 @@ module.exports = async () => {
   try {
     const packageInfo = await readPkgUp()
 
-    if (!packageInfo.pkg) throw Error('Empty package.json')
+    const data = packageInfo.pkg || packageInfo['package'] || packageInfo.packageJson;
+    if (!data) throw Error('Empty package.json')
 
     return {
-      name: packageInfo.pkg.name,
-      version: packageInfo.pkg.version,
-      description: packageInfo.pkg.description,
+      name: data.name,
+      version: data.version,
+      description: data.description,
     }
   } catch (e) {
     return null


### PR DESCRIPTION
Fix https://github.com/frinyvonnick/gitmoji-changelog/issues/181

package `read-pkg-up` has a breaking change on return object shape.

See:
1. `pkg` -> `package` https://github.com/sindresorhus/read-pkg-up/commit/1c15896aefca09af0be050eb27819ac6970362d4#diff-168726dbe96b3ce427e7fedce31bb0bc
2. `package` -> `packageJson` https://github.com/sindresorhus/read-pkg-up/commit/8140c731da0c4ddfedd549d55660acf0ee53ee1d#diff-168726dbe96b3ce427e7fedce31bb0bc
