### PR TITLE
✨ Add Helm preset

### DIFF
--- a/packages/gitmoji-changelog-cli/package.json
+++ b/packages/gitmoji-changelog-cli/package.json
@@ -46,6 +46,7 @@
     "semver-compare": "^1.0.0",
     "simple-git": "^1.113.0",
     "toml": "^3.0.0",
+    "yaml": "^1.10.2",
     "yargs": "^12.0.1"
   },
   "publishConfig": {

--- a/packages/gitmoji-changelog-cli/src/index.js
+++ b/packages/gitmoji-changelog-cli/src/index.js
@@ -47,7 +47,7 @@ yargs
   }, execute('update'))
 
   .option('format', { default: 'markdown', desc: 'changelog format (markdown, json)' })
-  .option('preset', { default: 'node', desc: 'define preset mode', choices: ['node', 'generic', 'maven', 'cargo'] })
+  .option('preset', { default: 'node', desc: 'define preset mode', choices: ['node', 'generic', 'maven', 'cargo', 'helm'] })
   .option('output', { desc: 'output changelog file' })
   .option('group-similar-commits', { desc: '[⚗️  - beta] try to group similar commits', default: false })
   .option('author', { default: false, desc: 'add the author in changelog lines' })

--- a/packages/gitmoji-changelog-cli/src/presets/helm.js
+++ b/packages/gitmoji-changelog-cli/src/presets/helm.js
@@ -1,0 +1,27 @@
+const yaml = require('yaml')
+const fs = require('fs')
+
+module.exports = async () => {
+  try {
+    const chartYamlPromise = new Promise((resolve, reject) => {
+      try {
+        resolve(yaml.parse(fs.readFileSync('Chart.yaml', 'utf-8')))
+      } catch (err) {
+        reject(err)
+      }
+    })
+
+    const {
+      name,
+      version,
+      description,
+    } = await chartYamlPromise
+    return {
+      name: name,
+      version: version,
+      description: description,
+    }
+  } catch (e) {
+    return null
+  }
+}

--- a/packages/gitmoji-changelog-cli/src/presets/helm.spec.js
+++ b/packages/gitmoji-changelog-cli/src/presets/helm.spec.js
@@ -1,0 +1,23 @@
+const fs = require('fs')
+
+const loadProjectInfo = require('./helm.js')
+
+describe('getPackageInfo', () => {
+  it('should extract info from Chart.yaml', async () => {
+    fs.readFileSync.mockReturnValue(`
+      name: chart-name
+      version: 0.1.1
+      description: Description of the chart
+    `)
+
+    const result = await loadProjectInfo()
+
+    expect(result).toEqual({
+      name: 'chart-name',
+      version: '0.1.1',
+      description: 'Description of the chart',
+    })
+  })
+})
+
+jest.mock('fs')

--- a/packages/gitmoji-changelog-documentation/README.md
+++ b/packages/gitmoji-changelog-documentation/README.md
@@ -156,6 +156,14 @@ The cargo preset looks for 3 properties in your `Cargo.toml`:
 - version
 - description
 
+#### Helm
+
+The helm preset looks for 3 properties in your `Chart.yaml`:
+
+- name
+- version
+- description
+
 ### Add a preset
 
 A preset need to export a function. When called this function must return three mandatory information about the project in which the cli has been called. The name of the project, a short description of it and its current version.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7817,6 +7817,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
 yargonaut@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/yargonaut/-/yargonaut-1.1.4.tgz#c64f56432c7465271221f53f5cc517890c3d6e0c"


### PR DESCRIPTION
Hi there 👋

I'm working on some Helm packages these times, and I figured that a Helm preset could be useful instead of maintaining a separate `.gitmoji-changelogrc` file.

So here is a PR implementing this :tada: 