### PR TITLE
✨ Add path arg to filter commits

### DIFF
--- a/packages/gitmoji-changelog-core/src/fromGitFile.js
+++ b/packages/gitmoji-changelog-core/src/fromGitFile.js
@@ -18,12 +18,13 @@ function parseCommit(commit) {
   }
 }
 
-function getCommits(from, to) {
+function getCommits(from, to, path = '.') {
   return new Promise(resolve => {
     gitRawCommits({
       format: COMMIT_FORMAT,
       from,
       to,
+      path,
     })
       .pipe(
         through.obj((data, enc, next) => {

--- a/packages/gitmoji-changelog-core/src/index.js
+++ b/packages/gitmoji-changelog-core/src/index.js
@@ -57,9 +57,10 @@ async function generateVersion(options) {
     version,
     groupSimilarCommits,
     client,
+    path,
   } = options
 
-  const rawCommits = await client.getCommits(from, to)
+  const rawCommits = await client.getCommits(from, to, path)
 
   let commits = filterCommits(rawCommits.map(parseCommit))
 
@@ -108,6 +109,7 @@ async function generateVersions({
   release,
   groupSimilarCommits,
   client,
+  path,
 }) {
   let nextTag = HEAD
   const targetVersion = hasNext ? 'next' : sanitizeVersion(release)
@@ -117,7 +119,7 @@ async function generateVersions({
     const to = nextTag
     nextTag = tag
     return generateVersion({
-      from, to, version, groupSimilarCommits, client,
+      from, to, version, groupSimilarCommits, client, path,
     })
   }))
     .then(versions => versions.sort(sortVersions))
@@ -126,7 +128,7 @@ async function generateVersions({
 }
 
 async function generateChangelog(from, to, {
-  groupSimilarCommits, client = fromGitFileClient,
+  groupSimilarCommits, client = fromGitFileClient, path,
 } = {}) {
   const gitTags = await client.getTags()
   let tagsToProcess = [...gitTags]
@@ -156,6 +158,7 @@ async function generateChangelog(from, to, {
     release: to,
     groupSimilarCommits,
     client,
+    path,
   })
 
   if (from !== TAIL && changes.length === 1 && isEmpty(changes[0].groups)) {


### PR DESCRIPTION
## Summary

TL;DR filter commits by path on changelog generation works, but untested.

As discussed in #158, after [this comment](https://github.com/frinyvonnick/gitmoji-changelog/issues/158#issuecomment-1055585316). One of the tasks to enabling per monorepo package changelogs is to filter commits from a folder.

The dependency responsible for fetching raw commits enables the path option from `git log` as seen in the docs [here](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/git-raw-commits#gitoptspath)

## Help Needed

- [ ] how to test this behavior with jest?
  - I've searched earlier this week how does git stores and tracks the folder structure, but could not understand enough to write a test case to improve code coverage with the new `getCommits` path option

## Missing features

- [ ] tests
- [ ] docs

## Test Plan

- run
```bash
node packages/gitmoji-changelog-cli/src/index.js --path packages/gitmoji-changelog-cli
```
  - The command is expected to fail with `FunctionalError: No changes found. You may need to fetch or pull the last changes.`
- Add a new comment to the selected testing folder (i.e `packages/gitmoji-changelog-cli`)
- Rerun changelog command with path argument
- The result will be something along the lines of
```md
<a name="0.0.1"></a>
## 0.0.1 (2022-03-06)

### Miscellaneous

- 🚧 test commit [[2640d11](https://github.com/thlmenezes/gitmoji-changelog/commit/2640d110fa580f6591df4fa188772c1b99f1f3ad)]
```
For reference, without the path argument my changelog for this pr becomes
```md
<a name="0.0.1"></a>
## 0.0.1 (2022-03-06)

### Added

- ✨ path option in generateChangelog [[66b0da7](https://github.com/thlmenezes/gitmoji-changelog/commit/66b0da7746e10ab04cecc6e510e9128570f6ef94)]
- ✨ path option to getCommits [[0b5eaef](https://github.com/thlmenezes/gitmoji-changelog/commit/0b5eaef34408d938a4d9c2c3f8134edf96f32d2c)]

### Miscellaneous

- 🚧 test commit [[2640d11](https://github.com/thlmenezes/gitmoji-changelog/commit/2640d110fa580f6591df4fa188772c1b99f1f3ad)]
```