### PR TITLE
🐛 Fix E2E tests and semver validation error type

### DIFF
--- a/packages/gitmoji-changelog-cli/src/cli.e2e.js
+++ b/packages/gitmoji-changelog-cli/src/cli.e2e.js
@@ -443,7 +443,7 @@ describe('generate changelog', () => {
   })
 
   async function makeChanges(fileName) {
-    fs.writeFileSync(path.join(testDir, fileName))
+    fs.writeFileSync(path.join(testDir, fileName), '')
   }
 
   async function makeCustomConfig(config) {

--- a/packages/gitmoji-changelog-cli/src/cli.js
+++ b/packages/gitmoji-changelog-cli/src/cli.js
@@ -6,7 +6,7 @@ const semver = require('semver')
 const semverCompare = require('semver-compare')
 const rc = require('rc')
 
-const { generateChangelog, logger } = require('@gitmoji-changelog/core')
+const { generateChangelog, logger, FunctionalError } = require('@gitmoji-changelog/core')
 const { buildMarkdownFile, getLatestVersion } = require('@gitmoji-changelog/markdown')
 
 const issueReporter = require('issue-reporter')
@@ -138,7 +138,7 @@ async function getChangelog(options, projectInfo) {
   const release = options.release === 'from-package' ? projectInfo.version : options.release
 
   if (!semver.valid(release)) {
-    throw new Error(`${release} is not a valid semver version.`)
+    throw new FunctionalError(`${release} is not a valid semver version.`)
   }
 
   const enhancedOptions = {

--- a/packages/gitmoji-changelog-core/src/index.js
+++ b/packages/gitmoji-changelog-core/src/index.js
@@ -187,4 +187,5 @@ function getLastCommitDate(commits) {
 module.exports = {
   generateChangelog,
   logger,
+  FunctionalError,
 }


### PR DESCRIPTION
This PR fixes issue #231. Node 14 doesn't seem to accept `undefined` as `data` arg to `fs.writeFileSync()`, so let's just pass an empty string.

Moreover, the last E2E test (_"generate changelog > update > should display an error if requested version isn't semver"_) expects an error to be logged when passed a non-semver `release` option. However the CLI throws a generic `Error` in these cases, which are eventually intercepted by the issue reporter instead of being logged: 

https://github.com/fredericbonnet/gitmoji-changelog/blob/4a293caece43a953940ed7d753387c41f5df33ab/packages/gitmoji-changelog-cli/src/cli.js#L105-L128

I don't think that's the intended behavior, so the fix is to throw a `FunctionalError` instead.

Happy Hacktoberfest! 🎃