### PR TITLE
✨ Add skip changelog function

### DIFF
--- a/packages/gitmoji-changelog-core/src/parser.js
+++ b/packages/gitmoji-changelog-core/src/parser.js
@@ -61,6 +61,11 @@ function parseCommit({
 }) {
   const { emoji, emojiCode, message } = parseSubject(subject)
   const group = getCommitGroup(emojiCode)
+  const bodyString = Array.isArray(body) ? body.join('\n') : body
+
+  const customConfiguration = rc('gitmoji-changelog')
+  const useSkipChangelog = customConfiguration ? customConfiguration.useSkipChangelog : undefined
+  const skipMatches = (message ? message.match(/\[skip cl]|\[skip changelog]/g) : null) != null || (bodyString ? bodyString.match(/\[skip cl]|\[skip changelog]/g) : null) != null
 
   return {
     hash,
@@ -70,9 +75,9 @@ function parseCommit({
     emojiCode,
     emoji,
     message,
-    group,
+    group: (useSkipChangelog === true && skipMatches === true) ? 'useless' : group,
     siblings: [],
-    body: Array.isArray(body) ? body.join('\n') : body,
+    body: bodyString,
   }
 }
 

--- a/packages/gitmoji-changelog-core/src/parser.spec.js
+++ b/packages/gitmoji-changelog-core/src/parser.spec.js
@@ -9,6 +9,26 @@ const sparklesCommit = {
   body: 'Waouh this is awesome 2',
 }
 
+const sparklesCommitSkipClInSubject = {
+  ...sparklesCommit,
+  subject: ':sparkles: Upgrade brand new feature [skip cl]',
+}
+
+const sparklesCommitSkipClInBody = {
+  ...sparklesCommit,
+  body: 'Waouh this is awesome 2 [skip cl]',
+}
+
+const sparklesCommitSkipChangelogInSubject = {
+  ...sparklesCommit,
+  subject: ':sparkles: Upgrade brand new feature [skip changelog]',
+}
+
+const sparklesCommitSkipChangelogInBody = {
+  ...sparklesCommit,
+  body: 'Waouh this is awesome 2 [skip changelog]',
+}
+
 describe('group mapping', () => {
   it('should place miscellaneous category at the end', () => {
     const mergeGroupMapping = getMergedGroupMapping([
@@ -78,6 +98,51 @@ describe('commits parser', () => {
     rc.mockImplementation(() => customConfiguration)
 
     expect(parseCommit(sparklesCommit)).toEqual(expect.objectContaining({ group: 'custom' }))
+  })
+
+  it('should handle skip cl in subject', () => {
+    const customConfiguration = {
+      useSkipChangelog: true,
+    }
+    rc.mockImplementation(() => customConfiguration)
+
+    expect(parseCommit(sparklesCommitSkipClInSubject)).toEqual(expect.objectContaining({ group: 'useless' }))
+  })
+
+  it('should handle skip cl in body', () => {
+    const customConfiguration = {
+      useSkipChangelog: true,
+    }
+    rc.mockImplementation(() => customConfiguration)
+
+    expect(parseCommit(sparklesCommitSkipClInBody)).toEqual(expect.objectContaining({ group: 'useless' }))
+  })
+
+  it('should handle skip changelog in subject', () => {
+    const customConfiguration = {
+      useSkipChangelog: true,
+    }
+    rc.mockImplementation(() => customConfiguration)
+
+    expect(parseCommit(sparklesCommitSkipChangelogInSubject)).toEqual(expect.objectContaining({ group: 'useless' }))
+  })
+
+  it('should handle skip changelog in body', () => {
+    const customConfiguration = {
+      useSkipChangelog: true,
+    }
+    rc.mockImplementation(() => customConfiguration)
+
+    expect(parseCommit(sparklesCommitSkipChangelogInBody)).toEqual(expect.objectContaining({ group: 'useless' }))
+  })
+
+  it('should handle disable skip changelog', () => {
+    const customConfiguration = {
+      useSkipChangelog: false,
+    }
+    rc.mockImplementation(() => customConfiguration)
+
+    expect(parseCommit(sparklesCommitSkipChangelogInBody)).toEqual(expect.objectContaining({ group: 'added' }))
   })
 })
 


### PR DESCRIPTION
## Summary
This PR adds skip changelog function. Commits with `[skip cl]` or `[skip changelog]` keyword can be filtered and will not be added to changelog.

The motivation behind this development is hide automated commits from GitHub Action or bots. Automated commits keeps a lot of space on changelog.

## Usage

For enabling function you need to add `"useSkipChangelog": true` to .gitmoji-changelogrc.

```diff
{
+    "useSkipChangelog": true
}
```

And you need to use `[skip cl]` or `[skip changelog]` keyword in commit's subject or body.

```diff
✨ Upgrade brand new feature [skip cl]
```