### PR TITLE
 ✨ Added poetry preset (for python packages)

### DIFF
--- a/packages/gitmoji-changelog-cli/src/index.js
+++ b/packages/gitmoji-changelog-cli/src/index.js
@@ -47,7 +47,7 @@ yargs
   }, execute('update'))
 
   .option('format', { default: 'markdown', desc: 'changelog format (markdown, json)' })
-  .option('preset', { default: 'node', desc: 'define preset mode', choices: ['node', 'generic', 'maven', 'cargo', 'helm'] })
+  .option('preset', { default: 'node', desc: 'define preset mode', choices: ['node', 'generic', 'maven', 'cargo', 'helm', 'poetry'] })
   .option('output', { desc: 'output changelog file' })
   .option('group-similar-commits', { desc: '[⚗️  - beta] try to group similar commits', default: false })
   .option('author', { default: false, desc: 'add the author in changelog lines' })

--- a/packages/gitmoji-changelog-cli/src/presets/poetry.js
+++ b/packages/gitmoji-changelog-cli/src/presets/poetry.js
@@ -1,0 +1,23 @@
+const toml = require('toml')
+const fs = require('fs')
+
+module.exports = async () => {
+  try {
+    const poetryPromise = new Promise((resolve, reject) => {
+      try {
+        resolve(toml.parse(fs.readFileSync('pyproject.toml', 'utf-8')))
+      } catch (err) {
+        reject(err)
+      }
+    })
+
+    const poetryInfo = await poetryPromise
+    return {
+      name: poetryInfo.tool.poetry.name,
+      version: poetryInfo.tool.poetry.version,
+      description: poetryInfo.tool.poetry.description,
+    }
+  } catch (e) {
+    return null
+  }
+}

--- a/packages/gitmoji-changelog-cli/src/presets/poetry.spec.js
+++ b/packages/gitmoji-changelog-cli/src/presets/poetry.spec.js
@@ -1,0 +1,25 @@
+const fs = require('fs')
+
+const loadProjectInfo = require('./poetry.js')
+
+describe('getPackageInfo', () => {
+  it('should extract info from pyproject.toml', async () =>{
+    fs.readFileSync.mockReturnValue(`
+      [tool.poetry]
+      name = "poetry-package-name"
+      version = "0.1.0"
+      description = "Description of the poetry package"
+    `)
+
+    const result = await loadProjectInfo()
+
+    expect(result).toEqual({
+      name: 'poetry-package-name',
+      version: '0.1.0',
+      description: 'Description of the poetry package',
+    })
+  })
+})
+
+
+jest.mock('fs')

--- a/packages/gitmoji-changelog-documentation/README.md
+++ b/packages/gitmoji-changelog-documentation/README.md
@@ -165,6 +165,14 @@ The helm preset looks for 3 properties in your `Chart.yaml`:
 - version
 - description
 
+#### Poetry
+
+The poetry preset looks for 3 properties in your `pyproject.toml`
+
+- name
+- version
+- description
+
 ### Add a preset
 
 A preset need to export a function. When called this function must return three mandatory information about the project in which the cli has been called. The name of the project, a short description of it and its current version.


### PR DESCRIPTION
Adds the ability to generate the gitmoji-changelog on python packages that utilize [Poetry](https://python-poetry.org/).
(with `--preset poetry` )

(I understand that the python eco-system for build-packaging tools is vast, but I've only implemented Poetry. If deemed necessary, I could also look into implementing a way to handle other python tools 👍 )