### PR TITLE
✨ Added python preset

### DIFF
--- a/packages/gitmoji-changelog-cli/src/index.js
+++ b/packages/gitmoji-changelog-cli/src/index.js
@@ -47,7 +47,7 @@ yargs
   }, execute('update'))
 
   .option('format', { default: 'markdown', desc: 'changelog format (markdown, json)' })
-  .option('preset', { default: 'node', desc: 'define preset mode', choices: ['node', 'generic', 'maven', 'cargo', 'helm'] })
+  .option('preset', { default: 'node', desc: 'define preset mode', choices: ['node', 'generic', 'maven', 'cargo', 'helm', 'python'] })
   .option('output', { desc: 'output changelog file' })
   .option('group-similar-commits', { desc: '[⚗️  - beta] try to group similar commits', default: false })
   .option('author', { default: false, desc: 'add the author in changelog lines' })

--- a/packages/gitmoji-changelog-cli/src/presets/python.js
+++ b/packages/gitmoji-changelog-cli/src/presets/python.js
@@ -1,0 +1,57 @@
+const toml = require('toml')
+const fs = require('fs')
+
+module.exports = async () => {
+  try {    
+    const pyprojectPromise = new Promise((resolve, reject) => {
+      try {
+        resolve(toml.parse(fs.readFileSync('pyproject.toml', 'utf-8')))
+      } catch (err) {
+        reject(err)
+      }
+    })
+
+    const projectFile = await pyprojectPromise
+    const name = recursiveKeySearch("name", projectFile)[0]
+    const version = recursiveKeySearch("version", projectFile)[0]
+    const description = recursiveKeySearch("description", projectFile)[0]
+
+    return {
+      name,
+      version,
+      description
+    }
+  } catch (e) {
+    return null
+  }
+}
+
+
+function recursiveKeySearch(key, data) {
+    //https://codereview.stackexchange.com/a/143914
+    if(data === null) {
+        return [];
+    }
+
+    if(data !== Object(data)) {
+        return [];
+    }
+
+    var results = [];
+
+    if(data.constructor === Array) {
+        for (var i = 0, len = data.length; i < len; i++) {
+            results = results.concat(recursiveKeySearch(key, data[i]));
+        }
+        return results;
+    }
+
+    for (var dataKey in data) {
+        if (key === dataKey) {
+            results.push(data[key]);
+        }
+        results = results.concat(recursiveKeySearch(key, data[dataKey]));
+    }
+
+    return results;
+}

--- a/packages/gitmoji-changelog-cli/src/presets/python.js
+++ b/packages/gitmoji-changelog-cli/src/presets/python.js
@@ -14,7 +14,17 @@ module.exports = async () => {
     const projectFile = await pyprojectPromise
     const name = recursiveKeySearch("name", projectFile)[0]
     const version = recursiveKeySearch("version", projectFile)[0]
-    const description = recursiveKeySearch("description", projectFile)[0]
+    let description = recursiveKeySearch("description", projectFile)[0]
+
+    if (!name){
+      throw new Error("Could not find name metadata in pyproject.toml")
+    }
+    if (!version){
+      throw new Error("Could not find version metadata in pyproject.toml")
+    }
+    if (!description){
+      description = ""
+    }
 
     return {
       name,

--- a/packages/gitmoji-changelog-cli/src/presets/python.js
+++ b/packages/gitmoji-changelog-cli/src/presets/python.js
@@ -2,7 +2,7 @@ const toml = require('toml')
 const fs = require('fs')
 
 module.exports = async () => {
-  try {    
+  try {
     const pyprojectPromise = new Promise((resolve, reject) => {
       try {
         resolve(toml.parse(fs.readFileSync('pyproject.toml', 'utf-8')))
@@ -12,24 +12,24 @@ module.exports = async () => {
     })
 
     const projectFile = await pyprojectPromise
-    const name = recursiveKeySearch("name", projectFile)[0]
-    const version = recursiveKeySearch("version", projectFile)[0]
-    let description = recursiveKeySearch("description", projectFile)[0]
+    const name = recursiveKeySearch('name', projectFile)[0]
+    const version = recursiveKeySearch('version', projectFile)[0]
+    let description = recursiveKeySearch('description', projectFile)[0]
 
-    if (!name){
-      throw new Error("Could not find name metadata in pyproject.toml")
+    if (!name) {
+      throw new Error('Could not find name metadata in pyproject.toml')
     }
-    if (!version){
-      throw new Error("Could not find version metadata in pyproject.toml")
+    if (!version) {
+      throw new Error('Could not find version metadata in pyproject.toml')
     }
-    if (!description){
-      description = ""
+    if (!description) {
+      description = ''
     }
 
     return {
       name,
       version,
-      description
+      description,
     }
   } catch (e) {
     return null
@@ -38,30 +38,31 @@ module.exports = async () => {
 
 
 function recursiveKeySearch(key, data) {
-    //https://codereview.stackexchange.com/a/143914
-    if(data === null) {
-        return [];
+  // https://codereview.stackexchange.com/a/143914
+  if (data === null) {
+    return []
+  }
+
+  if (data !== Object(data)) {
+    return []
+  }
+
+  let results = []
+
+  if (data.constructor === Array) {
+    for (let i = 0, len = data.length; i < len; i += 1) {
+      results = results.concat(recursiveKeySearch(key, data[i]))
     }
+    return results
+  }
 
-    if(data !== Object(data)) {
-        return [];
+  for (let i = 0; i < Object.keys(data).length; i += 1) {
+    const dataKey = Object.keys(data)[i]
+    if (key === dataKey) {
+      results.push(data[key])
     }
+    results = results.concat(recursiveKeySearch(key, data[dataKey]))
+  }
 
-    var results = [];
-
-    if(data.constructor === Array) {
-        for (var i = 0, len = data.length; i < len; i++) {
-            results = results.concat(recursiveKeySearch(key, data[i]));
-        }
-        return results;
-    }
-
-    for (var dataKey in data) {
-        if (key === dataKey) {
-            results.push(data[key]);
-        }
-        results = results.concat(recursiveKeySearch(key, data[dataKey]));
-    }
-
-    return results;
+  return results
 }

--- a/packages/gitmoji-changelog-cli/src/presets/python.spec.js
+++ b/packages/gitmoji-changelog-cli/src/presets/python.spec.js
@@ -1,0 +1,87 @@
+const fs = require('fs')
+
+const loadProjectInfo = require('./python.js')
+
+describe('getPackageInfo', () => {
+  it('should extract info from a pyproject.toml made by poetry', async () =>{
+    // Note the TOML section is distinct for poetry
+    fs.readFileSync.mockReturnValue(`
+      [tool.poetry]
+      name = "poetry-package-name"
+      version = "0.1.0"
+      description = "Description of the poetry package"
+    `)
+
+    const result = await loadProjectInfo()
+
+    expect(result).toEqual({
+      name: 'poetry-package-name',
+      version: '0.1.0',
+      description: 'Description of the poetry package',
+    })
+  })
+
+  it('should extract info from the PEP621 example pyproject.toml', async () =>{
+    // [project] is the usual TOML section for the metadata 
+    fs.readFileSync.mockReturnValue(`
+      [project]
+      name = "spam"
+      version = "2020.0.0"
+      description = "Lovely Spam! Wonderful Spam!"
+      readme = "README.rst"
+      requires-python = ">=3.8"
+      license = {file = "LICENSE.txt"}
+      keywords = ["egg", "bacon", "sausage", "tomatoes", "Lobster Thermidor"]
+      authors = [
+        {email = "hi@pradyunsg.me"},
+        {name = "Tzu-Ping Chung"}
+      ]
+      maintainers = [
+        {name = "Brett Cannon", email = "brett@python.org"}
+      ]
+      classifiers = [
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python"
+      ]
+      
+      dependencies = [
+        "httpx",
+        "gidgethub[httpx]>4.0.0",
+        "django>2.1; os_name != 'nt'",
+        "django>2.0; os_name == 'nt'"
+      ]
+      
+      [project.optional-dependencies]
+      test = [
+        "pytest < 5.0.0",
+        "pytest-cov[all]"
+      ]
+      
+      [project.urls]
+      homepage = "example.com"
+      documentation = "readthedocs.org"
+      repository = "github.com"
+      changelog = "github.com/me/spam/blob/master/CHANGELOG.md"
+      
+      [project.scripts]
+      spam-cli = "spam:main_cli"
+      
+      [project.gui-scripts]
+      spam-gui = "spam:main_gui"
+      
+      [project.entry-points."spam.magical"]
+      tomatoes = "spam:main_tomatoes"
+    `)
+
+    const result = await loadProjectInfo()
+
+    expect(result).toEqual({
+      name: 'spam',
+      version: '2020.0.0',
+      description: 'Lovely Spam! Wonderful Spam!',
+    })
+  })
+})
+
+
+jest.mock('fs')

--- a/packages/gitmoji-changelog-cli/src/presets/python.spec.js
+++ b/packages/gitmoji-changelog-cli/src/presets/python.spec.js
@@ -22,7 +22,7 @@ describe('getPackageInfo', () => {
   })
 
   it('should extract metadata from the PEP621 example pyproject.toml', async () =>{
-    // [project] is the usual TOML section for the metadata 
+    // [project] is the usual TOML section for the metadata
     fs.readFileSync.mockReturnValue(`
       [project]
       name = "spam"
@@ -101,7 +101,7 @@ describe('getPackageInfo', () => {
   })
 
   it('should use the first metadata value found from the top', async () =>{
-    // Only the first occurance of the expected key names are taken. 
+    // Only the first occurance of the expected key names are taken.
     fs.readFileSync.mockReturnValue(`
       [other.section]
       somebody = "once told me the"

--- a/packages/gitmoji-changelog-documentation/README.md
+++ b/packages/gitmoji-changelog-documentation/README.md
@@ -165,6 +165,14 @@ The helm preset looks for 3 properties in your `Chart.yaml`:
 - version
 - description
 
+#### Python
+
+The python preset looks for 3 properties in your `pyproject.toml`:
+
+- name
+- version
+- description
+
 ### Add a preset
 
 A preset need to export a function. When called this function must return three mandatory information about the project in which the cli has been called. The name of the project, a short description of it and its current version.

--- a/packages/gitmoji-changelog-documentation/README.md
+++ b/packages/gitmoji-changelog-documentation/README.md
@@ -173,6 +173,8 @@ The python preset looks for 3 properties in your `pyproject.toml`:
 - version
 - description
 
+(The value taken is the first one found in your `pyproject.toml` that matches the expected key name given above.)
+
 ### Add a preset
 
 A preset need to export a function. When called this function must return three mandatory information about the project in which the cli has been called. The name of the project, a short description of it and its current version.


### PR DESCRIPTION
Adds the `python` preset to generate the gitmoji-changelog.

This should cover any python package that follows [PEP621](https://peps.python.org/pep-0621/), and it also covers poetry's distinct metadata section (I am unaware of other distinctions but they should also be covered by this).


