### PR TITLE
🐛 Fix broken options --group-similar-commits, --author and --interactive

### DIFF
--- a/packages/gitmoji-changelog-cli/src/index.js
+++ b/packages/gitmoji-changelog-cli/src/index.js
@@ -49,9 +49,11 @@ yargs
   .option('format', { default: 'markdown', desc: 'changelog format (markdown, json)' })
   .option('preset', { default: 'node', desc: 'define preset mode', choices: ['node', 'generic', 'maven', 'cargo', 'helm', 'python'] })
   .option('output', { desc: 'output changelog file' })
-  .option('group-similar-commits', { desc: '[⚗️  - beta] try to group similar commits', default: false })
-  .option('author', { default: false, desc: 'add the author in changelog lines' })
-  .option('interactive', { default: false, desc: 'select commits manually', alias: 'i' })
+  .option('group-similar-commits', { desc: '[⚗️  - beta] try to group similar commits', default: false, type: 'boolean' })
+  .option('author', { default: false, desc: 'add the author in changelog lines', type: 'boolean' })
+  .option('interactive', {
+    default: false, desc: 'select commits manually', alias: 'i', type: 'boolean',
+  })
 
   .help('help')
   .epilog(`For more information visit: ${homepage}`)


### PR DESCRIPTION
Boolean flags (`--author`, `--interactive`, and `--group-similar-commits`) were incorrectly declared in the code, which made it necessary to explicitly pass a value (e.g. `--author 1`) for them to work.

Using them as plain flags (like `--author`) didn't work as expected.

This has now been fixed — the flags behave properly and no longer require values.
