### PR TITLE
✨ Add --only-stable option to include only stable versions

### DIFF
--- a/packages/gitmoji-changelog-cli/src/index.js
+++ b/packages/gitmoji-changelog-cli/src/index.js
@@ -52,6 +52,7 @@ yargs
   .option('group-similar-commits', { desc: '[⚗️  - beta] try to group similar commits', default: false })
   .option('author', { default: false, desc: 'add the author in changelog lines' })
   .option('interactive', { default: false, desc: 'select commits manually', alias: 'i' })
+  .option('only-stable', { default: false, desc: 'Include only stable versions when generating the changelog', type: 'boolean' })
 
   .help('help')
   .epilog(`For more information visit: ${homepage}`)

--- a/packages/gitmoji-changelog-core/src/index.js
+++ b/packages/gitmoji-changelog-core/src/index.js
@@ -126,9 +126,13 @@ async function generateVersions({
 }
 
 async function generateChangelog(from, to, {
-  groupSimilarCommits, client = fromGitFileClient,
+  groupSimilarCommits, onlyStable, client = fromGitFileClient,
 } = {}) {
-  const gitTags = await client.getTags()
+  let gitTags = await client.getTags()
+  if (onlyStable) {
+    gitTags = gitTags.filter((tag) => !/(dev|rc|alpha|beta)/i.test(tag))
+  }
+
   let tagsToProcess = [...gitTags]
   const hasNext = hasNextVersion(gitTags, to)
 

--- a/packages/gitmoji-changelog-core/src/index.spec.js
+++ b/packages/gitmoji-changelog-core/src/index.spec.js
@@ -362,6 +362,32 @@ describe('changelog', () => {
         { date: '2019-02-01T00:00:00+00:00', body: '9' },
       ])
   })
+
+  it('should include unstable commits', async () => {
+    mockGroup([recycleCommit])
+    mockGroup([lipstickCommit])
+    mockGroup([sparklesCommit])
+    mockGroup([lockCommit])
+
+    gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.0', 'v1.0.0-dev.1', 'v1.0.1']))
+
+    const { changes } = await generateChangelog(TAIL, HEAD, { onlyStable: false })
+
+    expect(changes).toHaveLength(4)
+  })
+
+  it('should exclude unstable commits', async () => {
+    mockGroup([recycleCommit])
+    mockGroup([lipstickCommit])
+    mockGroup([sparklesCommit])
+    mockGroup([lockCommit])
+
+    gitSemverTags.mockImplementation(cb => cb(null, ['v1.0.0', 'v1.0.0-dev.1', 'v1.0.1']))
+
+    const { changes } = await generateChangelog(TAIL, HEAD, { onlyStable: true })
+
+    expect(changes).toHaveLength(3)
+  })
 })
 
 jest.mock('git-raw-commits')

--- a/packages/gitmoji-changelog-documentation/README.md
+++ b/packages/gitmoji-changelog-documentation/README.md
@@ -62,6 +62,7 @@ The first command listed above is the idiomatic usage of `gitmoji-changelog` (re
 | --group-similar-commits | [⚗️,- beta] try to group similar commits | false                              |
 | --author                | add the author in changelog lines       | false                              |
 | --interactive -i        | select commits manually                 | false                              |
+| --only-stable           | Include only stable versions when generating the changelog | false           |
 | --help                  | display help                            |                                    |
 
 ### Example


### PR DESCRIPTION
Added a new CLI option: `--only-stable`

When enabled, this option filters the changelog to include **only stable releases** — i.e., versions that don’t contain pre-release markers like: `alpha`, `beta`, `rc`, `dev`

This is useful if you want a clean changelog that reflects only production-ready versions.

For example, when developing a new feature, several intermediate versions may be released, such as `2.0.0-dev.1`, `2.0.0-dev.2`, `2.0.0-dev.3`, `2.0.0-rc.1`, etc. The repository will likely contain tags for all of these versions. As a result, using gitmoji-changelog will add each of them to the CHANGELOG as a full release, which might not be desirable. I want my CHANGELOG to exclude such intermediate versions and remain cleaner. This option makes that possible.
